### PR TITLE
Switch to modelcontextprotocol SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project will implement all three components to demonstrate a complete MCP w
 
 ## Project Goal
 
-The primary goal of this repository is to provide a clear and simple example of how to implement MCP using the official [`@mcp/typescript-sdk`](https://www.google.com/search?q=%5Bhttps://github.com/modelcontextprotocol/typescript-sdk%5D\(https://github.com/modelcontextprotocol/typescript-sdk\)).
+The primary goal of this repository is to provide a clear and simple example of how to implement MCP using the official [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk).
 
 By the end of this project, you will have:
 
@@ -31,7 +31,7 @@ By the end of this project, you will have:
 
   * **Backend**: [Node.js](https://nodejs.org/) with [Express](https://expressjs.com/) for the MCP Server.
   * **Frontend**: Plain HTML, CSS, and TypeScript for the Host and Client.
-  * **MCP Implementation**: [`@mcp/typescript-sdk`](https://www.google.com/search?q=%5Bhttps://github.com/modelcontextprotocol/typescript-sdk%5D\(https://github.com/modelcontextprotocol/typescript-sdk\)).
+  * **MCP Implementation**: [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk).
   * **Build Tool**: `tsc` (the TypeScript compiler) and `ts-node-dev` for easy development.
 
 -----
@@ -61,8 +61,8 @@ Here is a step-by-step plan to build our MCP proof-of-concept. Each step will be
 
   * [x] **Task 2: Install Dependencies**
 
-      * Install `express` and `@mcp/typescript-sdk` in the `server` package.
-      * Install `@mcp/typescript-sdk` in the `client` package.
+      * Install `express` and `@modelcontextprotocol/sdk` in the `server` package.
+      * Install `@modelcontextprotocol/sdk` in the `client` package.
       * Install development dependencies like `typescript`, `ts-node-dev`, and `@types/express` at the root level.
 
 ### Phase 2: Server Implementation

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,6 +8,6 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcp/typescript-sdk": "^0.0.1"
+    "@modelcontextprotocol/sdk": "^0.0.1"
   }
 }

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,4 +1,4 @@
-import { McpClient } from '@mcp/typescript-sdk';
+import { McpClient } from '@modelcontextprotocol/sdk';
 
 // Connect to the MCP server running on localhost
 const client = new McpClient({ server: 'http://localhost:3000' });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "@mcp/typescript-sdk": "^0.0.1"
+    "@modelcontextprotocol/sdk": "^0.0.1"
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { McpServer } from '@mcp/typescript-sdk';
+import { McpServer } from '@modelcontextprotocol/sdk';
 
 // Simple Express application that hosts an MCP server
 const app = express();


### PR DESCRIPTION
## Summary
- use `@modelcontextprotocol/sdk` instead of the old MCP SDK
- update imports in client and server code
- adjust README instructions

## Testing
- `npm run build --workspace packages/client` *(fails: Cannot find module '@modelcontextprotocol/sdk')*
- `npm run build --workspace packages/server` *(fails: Cannot find module '@modelcontextprotocol/sdk')*