### PR TITLE
Integrate Garmin Connect mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ graph TD
     Host --> Client
     Client --> Server
     Server --> Model
+    Server --> GarminConnect
 ```
 
 -----
@@ -128,6 +129,18 @@ Here is a step-by-step plan to build our MCP proof-of-concept. Each step will be
 3. Start the server in development mode: `npm run dev --workspace=packages/server`.
 4. Serve the host application using `npm run start --workspace=packages/host` and open it in your browser.
 5. Type text into the textarea and click **Send Context** to see the server log the received context.
+
+## Garmin Connect Integration
+
+The server exposes a new MCP tool `garmin.activities` and a REST endpoint `/garmin/activities`.
+Set the following environment variables before starting the server:
+
+```
+GARMIN_EMAIL=<your email>
+GARMIN_PASSWORD=<your password>
+```
+
+These credentials are used to authenticate with Garmin Connect. The current implementation returns mocked data but can be replaced with a proper Garmin Connect client.
 
 
 -----

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.2.0",
     "live-server": "^1.2.1"
+  },
+  "scripts": {
+    "test": "npm run build --workspace=packages/server && node --test packages/server/test"
   }
 }

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,4 +1,4 @@
-import { McpClient } from '@modelcontextprotocol/sdk';
+import { McpClient } from '@modelcontextprotocol/sdk/client/index.js';
 
 // Connect to the MCP server running on localhost
 const client = new McpClient({ server: 'http://localhost:3000' });

--- a/packages/server/src/garmin.ts
+++ b/packages/server/src/garmin.ts
@@ -1,0 +1,27 @@
+export interface GarminActivity {
+  date: string;
+  steps: number;
+}
+
+/**
+ * Fetch activity data from Garmin Connect.
+ *
+ * This implementation uses environment variables `GARMIN_EMAIL` and
+ * `GARMIN_PASSWORD` to authenticate. In a real implementation you would
+ * use a Garmin Connect API client. Here we return mocked data so the
+ * project can run offline.
+ */
+export async function fetchGarminData(): Promise<GarminActivity[]> {
+  const { GARMIN_EMAIL, GARMIN_PASSWORD } = process.env;
+  if (!GARMIN_EMAIL || !GARMIN_PASSWORD) {
+    throw new Error('GARMIN_EMAIL and GARMIN_PASSWORD must be set');
+  }
+
+  // TODO: Replace this mock with calls to an actual Garmin Connect client.
+  return [
+    {
+      date: new Date().toISOString().substring(0, 10),
+      steps: 1234,
+    },
+  ];
+}

--- a/packages/server/test/garmin.test.js
+++ b/packages/server/test/garmin.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createApp } from '../dist/index.js';
+import { fetchGarminData } from '../dist/garmin.js';
+import http from 'node:http';
+import { once } from 'node:events';
+
+// Ensure environment variables are set for tests
+process.env.GARMIN_EMAIL = 'user@example.com';
+process.env.GARMIN_PASSWORD = 'secret';
+
+test('fetchGarminData returns mock data', async () => {
+  const data = await fetchGarminData();
+  assert.ok(Array.isArray(data));
+  assert.ok(data.length > 0);
+});
+
+test('GET /garmin/activities returns data', async () => {
+  const app = createApp();
+  const server = http.createServer(app);
+  server.listen(0);
+  await once(server, 'listening');
+  const { port } = server.address();
+  const res = await fetch(`http://localhost:${port}/garmin/activities`);
+  const body = await res.json();
+  assert.ok(Array.isArray(body));
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add placeholder Garmin Connect client and register an MCP tool
- expose `/garmin/activities` endpoint in the server
- adjust client to import from SDK subpath
- document new Garmin Connect integration and update architecture diagram
- add node:test based integration tests

## Testing
- `node --test packages/server/test`
