### PR TITLE
Add NLP-based Garmin query tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore build outputs
 packages/*/dist/
+packages/*/*.tsbuildinfo
 node_modules/

--- a/README.md
+++ b/README.md
@@ -132,7 +132,12 @@ Here is a step-by-step plan to build our MCP proof-of-concept. Each step will be
 
 ## Garmin Connect Integration
 
-The server exposes a new MCP tool `garmin.activities` and a REST endpoint `/garmin/activities`.
+The server exposes MCP tools for Garmin integration:
+
+* `garmin.activities` – returns recent activity data.
+* `garmin.query` – interprets a natural language query and returns Garmin information using a lightweight NLP agent.
+
+There are also REST endpoints `/garmin/activities` and `/garmin/query`.
 Set the following environment variables before starting the server:
 
 ```

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,7 +1,7 @@
-import { McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
 
 // Connect to the MCP server running on localhost
-const client = new McpClient({ server: 'http://localhost:3000' });
+const client: any = new McpClient({ server: 'http://localhost:3000' } as any);
 
 // Helper to send the textarea content as context
 function sendContext() {

--- a/packages/server/src/garmin.ts
+++ b/packages/server/src/garmin.ts
@@ -18,10 +18,15 @@ export async function fetchGarminData(): Promise<GarminActivity[]> {
   }
 
   // TODO: Replace this mock with calls to an actual Garmin Connect client.
-  return [
-    {
-      date: new Date().toISOString().substring(0, 10),
-      steps: 1234,
-    },
-  ];
+  // Generate mock data for the last 3 days so our NLP queries have something
+  // interesting to work with.
+  const today = new Date();
+  return Array.from({ length: 3 }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    return {
+      date: d.toISOString().substring(0, 10),
+      steps: 1000 + i * 500,
+    };
+  });
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,16 +1,36 @@
 import express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { fetchGarminData } from './garmin';
+import { parseQuery } from './nlpAgent';
+import { z } from 'zod';
+
+async function handleQuery(query: string) {
+  const intent = parseQuery(query);
+  const activities = await fetchGarminData();
+
+  if (intent.intent === 'steps' && intent.date) {
+    const match = activities.find(a => a.date === intent.date);
+    return { steps: match?.steps ?? null };
+  }
+
+  return { activities };
+}
 
 export function createApp() {
   const app = express();
 
-  const mcp = new McpServer({ app });
+  const mcp: any = new McpServer({ app } as any);
 
   // MCP tool to fetch Garmin data
   mcp.tool('garmin.activities', async () => {
     const activities = await fetchGarminData();
-    return { activities };
+    return { content: [{ type: 'text', text: JSON.stringify(activities) }] };
+  });
+
+  // MCP tool that accepts a natural language query and returns Garmin data
+  mcp.tool('garmin.query', { query: z.string().describe('Natural language query') }, async ({ query }: { query: string }) => {
+    const result = await handleQuery(query);
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
   });
 
   app.get('/', (_req, res) => {
@@ -22,6 +42,17 @@ export function createApp() {
     try {
       const activities = await fetchGarminData();
       res.json(activities);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // REST endpoint to query Garmin data using natural language
+  app.post('/garmin/query', express.json(), async (req, res) => {
+    try {
+      const { query } = req.body as { query: string };
+      const result = await handleQuery(query);
+      res.json(result);
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }

--- a/packages/server/src/nlpAgent.ts
+++ b/packages/server/src/nlpAgent.ts
@@ -1,0 +1,36 @@
+export interface QueryResult {
+  date?: string;
+  intent: 'steps' | 'activities' | 'unknown';
+}
+
+/**
+ * Very naive NLP parser to extract simple queries about Garmin data.
+ * This mimics using an LLM agent but works offline.
+ */
+export function parseQuery(query: string): QueryResult {
+  const lower = query.toLowerCase();
+  const result: QueryResult = { intent: 'unknown' };
+
+  if (lower.includes('step')) {
+    result.intent = 'steps';
+  } else if (lower.includes('activit')) {
+    result.intent = 'activities';
+  }
+
+  // Recognize "today" or "yesterday" or explicit YYYY-MM-DD
+  const today = new Date();
+  if (lower.includes('today')) {
+    result.date = today.toISOString().substring(0, 10);
+  } else if (lower.includes('yesterday')) {
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    result.date = yesterday.toISOString().substring(0, 10);
+  } else {
+    const match = lower.match(/(\d{4}-\d{2}-\d{2})/);
+    if (match) {
+      result.date = match[1];
+    }
+  }
+
+  return result;
+}

--- a/packages/server/test/garmin.test.js
+++ b/packages/server/test/garmin.test.js
@@ -26,3 +26,19 @@ test('GET /garmin/activities returns data', async () => {
   assert.ok(Array.isArray(body));
   server.close();
 });
+
+test('POST /garmin/query returns steps for today', async () => {
+  const app = createApp();
+  const server = http.createServer(app);
+  server.listen(0);
+  await once(server, 'listening');
+  const { port } = server.address();
+  const res = await fetch(`http://localhost:${port}/garmin/query`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: 'steps today' })
+  });
+  const body = await res.json();
+  assert.ok('steps' in body);
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add lightweight NLP parser
- expand mocked Garmin data for multiple days
- expose new `garmin.query` MCP tool and REST endpoint
- update README with new tool info
- test new NLP query endpoint

## Testing
- `npm test`